### PR TITLE
Rocky 9 build support

### DIFF
--- a/calcPv/calcPerform.c
+++ b/calcPv/calcPerform.c
@@ -21,6 +21,7 @@
 
 #include "postfix.h"
 #include "postfixPvt.h"
+#include "errlog.h"
 
 #ifdef SOLARIS
 #include <ieeefp.h>

--- a/configure/CONFIG_SITE.rhel9-x86_64.rhel9-x86_64
+++ b/configure/CONFIG_SITE.rhel9-x86_64.rhel9-x86_64
@@ -1,0 +1,25 @@
+#
+# CONFIG_SITE.rhel9-x86_64.rhel9-x86_64
+#
+# Site Specific Configuration Information
+# Only the local epics system manager should modify this file
+
+# Where to find utilities/libraries
+#       If you do not have a certain product,
+#       leave the line empty.
+#
+
+# RHEL9 uses gcc 11
+CXX_STD = c++11
+
+#With the release of Fedora Core 5 the 
+#X11 and MOTIF libraries now live at /usr/lib64
+X11_LIB=/usr/lib64
+X11_INC=/usr/include/X11
+MOTIF_LIB=/usr/lib64
+MOTIF_INC=/usr/include
+GIF_LIB=/usr/lib64
+GIF_INC=/usr/include
+PNG_LIB=/usr/lib64
+PNG_INC=/usr/include
+

--- a/giflib/Makefile
+++ b/giflib/Makefile
@@ -11,16 +11,16 @@ GIF_INC ?= /usr/include
    USR_LIBS += 114135a4-6f6c-11d3-95bc-00104b8742df
 
    USR_LIBS_Linux += Xm Xt Xp Xtst X11
-   USR_SYS_LIBS_Linux += pthread dl ungif gif
+   USR_SYS_LIBS_Linux += pthread dl gif
 
    USR_LIBS_Darwin += Xm Xt Xp Xtst X11
-   USR_SYS_LIBS_Darwin += pthread dl ungif gif
+   USR_SYS_LIBS_Darwin += pthread dl gif
 
    USR_LIBS_solaris += Xm Xt Xmu X11 Xext
-   USR_SYS_LIBS_solaris += pthread dl rt ungif gif
+   USR_SYS_LIBS_solaris += pthread dl rt gif
 
    USR_LIBS_hpux11_11_mt = Xm Xt X11 Xext
-   USR_SYS_LIBS_hpux11_11_mt = pthread ungif gif
+   USR_SYS_LIBS_hpux11_11_mt = pthread gif
 
    LIBRARY = cf322683-513e-4570-a44b-7cdd7cae0de5
 

--- a/giflib/gif.cc
+++ b/giflib/gif.cc
@@ -16,14 +16,6 @@
 //  along with this program; if not, write to the Free Software
 //  Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
 
-#if GIFLIB_MAJOR > 5 || GIFLIB_MAJOR == 5 && GIFLIB_MINOR >= 1
-  #define GIF_CLOSE_FILE(gif) DGifCloseFile(gif, NULL)
-  #define GIF_OPEN_FILE(gif) DGifOpenFileName(gif, NULL)
-#else
-  #define GIF_CLOSE_FILE(gif) DGifCloseFile(gif)
-  #define GIF_OPEN_FILE(gif) DGifOpenFileName(gif)
-#endif
-
 void printErrMsg (
   const char *fileName,
   int lineNum,
@@ -39,6 +31,14 @@ void printErrMsg (
 #include "gif.h"
 #include "app_pkg.h"
 #include "act_win.h"
+
+#if defined(GIFLIB_MAJOR) && (GIFLIB_MAJOR > 5 || (GIFLIB_MAJOR == 5 && GIFLIB_MINOR >= 1))
+  #define GIF_CLOSE_FILE(gif) DGifCloseFile(gif, NULL)
+  #define GIF_OPEN_FILE(gif) DGifOpenFileName(gif, NULL)
+#else
+  #define GIF_CLOSE_FILE(gif) DGifCloseFile(gif)
+  #define GIF_OPEN_FILE(gif) DGifOpenFileName(gif)
+#endif
 
 #include "thread.h"
 

--- a/imagelib/gif.cc
+++ b/imagelib/gif.cc
@@ -16,14 +16,6 @@
 //  along with this program; if not, write to the Free Software
 //  Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
 
-#if GIFLIB_MAJOR > 5 || GIFLIB_MAJOR == 5 && GIFLIB_MINOR >= 1
-  #define GIF_CLOSE_FILE(gif) DGifCloseFile(gif, NULL)
-  #define GIF_OPEN_FILE(gif) DGifOpenFileName(gif, NULL)
-#else
-  #define GIF_CLOSE_FILE(gif) DGifCloseFile(gif)
-  #define GIF_OPEN_FILE(gif) DGifOpenFileName(gif)
-#endif
-
 void printErrMsg (
   const char *fileName,
   int lineNum,
@@ -39,6 +31,14 @@ void printErrMsg (
 #include "gif.h"
 #include "app_pkg.h"
 #include "act_win.h"
+
+#if defined(GIFLIB_MAJOR) && (GIFLIB_MAJOR > 5 || (GIFLIB_MAJOR == 5 && GIFLIB_MINOR >= 1))
+  #define GIF_CLOSE_FILE(gif) DGifCloseFile(gif, NULL)
+  #define GIF_OPEN_FILE(gif) DGifOpenFileName(gif, NULL)
+#else
+  #define GIF_CLOSE_FILE(gif) DGifCloseFile(gif)
+  #define GIF_OPEN_FILE(gif) DGifOpenFileName(gif)
+#endif
 
 #include "thread.h"
 


### PR DESCRIPTION
* Add build support for rocky9/rhel9
* ungif isn't needed and isn't available on rocky 9, so don't link against it
* Add missing errlog.h include
* Fix giflib > 5.1 ifdef logic

Tested build on psbuild-rhel7 and psbuild-rocky9